### PR TITLE
Improve contact page layout

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -17,7 +17,7 @@
         <!-- Core theme CSS (includes Bootstrap)-->
         <link href="css/styles.css" rel="stylesheet" />
     </head>
-    <body class="d-flex flex-column">
+    <body class="d-flex flex-column h-100 bg-light">
         <main class="flex-shrink-0">
             <!-- Navigation-->
             <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
@@ -37,19 +37,29 @@
             <!-- Page content-->
             <section class="py-5">
                 <div class="container px-5">
-                    <div class="row gx-5 justify-content-center">
-                        <div class="col-lg-6">
-                            <div class="text-center mb-5">
-                                <h2 class="fw-bolder">Contact</h2>
-                                <p class="lead fw-normal text-muted mb-0">Feel free to reach out!</p>
+                    <div class="row gx-5 justify-content-center align-items-center">
+                        <div class="col-lg-5 mb-5 mb-lg-0">
+                            <div class="text-center">
+                                <img class="img-fluid rounded-circle mb-4" src="assets/profile.png" alt="Profile" style="max-width: 200px;" />
+                                <h3 class="fw-bolder">Fun Fact</h3>
+                                <p class="text-muted">I can solve a Rubik's Cube in under a minute!</p>
+                                <div class="d-flex justify-content-center fs-2 gap-3">
+                                    <a class="text-gradient" href="https://www.instagram.com/kruz_4/"><i class="bi bi-instagram"></i></a>
+                                </div>
                             </div>
-                            <ul class="list-unstyled text-center">
-                                <li class="mb-3"><i class="bi bi-geo-alt me-2"></i>Rochester, NY</li>
-                                <li class="mb-3"><i class="bi bi-telephone me-2"></i>585-957-2641</li>
-                                <li class="mb-3"><i class="bi bi-envelope me-2"></i><a href="mailto:krutikpanchal44@gmail.com">krutikpanchal44@gmail.com</a></li>
-                                <li class="mb-3"><i class="bi bi-linkedin me-2"></i><a href="https://www.linkedin.com/in/panchalkrutik">linkedin.com/in/panchalkrutik</a></li>
-                                <li><i class="bi bi-github me-2"></i><a href="https://github.com/Krutik4">github.com/Krutik4</a></li>
-                            </ul>
+                        </div>
+                        <div class="col-lg-5">
+                            <div class="text-center">
+                                <h2 class="fw-bolder">Let's Connect</h2>
+                                <p class="lead fw-normal text-muted mb-4">I'd love to collaborate and discuss new ideas.</p>
+                                <div class="d-flex justify-content-center fs-1 gap-4">
+                                    <a class="text-gradient" href="https://www.google.com/maps/place/Rochester,+NY"><i class="bi bi-geo-alt"></i></a>
+                                    <a class="text-gradient" href="tel:5859572641"><i class="bi bi-telephone"></i></a>
+                                    <a class="text-gradient" href="mailto:krutikpanchal44@gmail.com"><i class="bi bi-envelope"></i></a>
+                                    <a class="text-gradient" href="https://www.linkedin.com/in/panchalkrutik"><i class="bi bi-linkedin"></i></a>
+                                    <a class="text-gradient" href="https://github.com/Krutik4"><i class="bi bi-github"></i></a>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- restyle contact page to match the rest of the site
- split contact page into two columns
- add a fun fact with an Instagram icon
- show larger contact icons only

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687480deb470832da363162260f365e3