### PR TITLE
Update resume timeline design

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -11740,25 +11740,20 @@ html {
 
 /* Timeline date markers used on the resume page */
 .date-path {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  height: 100%;
+  position: relative;
+  width: 100%;
+  height: 6rem;
 }
 .date-path .line {
-  flex-grow: 1;
-  width: 2px;
-  background-image: linear-gradient(
-    to bottom,
-    var(--bs-primary) 33%,
-    rgba(255, 255, 255, 0) 0%
-  );
-  background-position: right;
-  background-size: 2px 8px;
-  background-repeat: repeat-y;
-  transition: background-color 0.3s ease;
+  position: absolute;
+  inset: 0;
+}
+.date-path .line svg {
+  width: 100%;
+  height: 100%;
 }
 .date-path .date-marker {
+  position: absolute;
   background-color: var(--bs-primary);
   color: #fff;
   padding: 0.25rem 0.5rem;
@@ -11767,18 +11762,14 @@ html {
   line-height: 1;
   text-align: center;
   font-weight: 600;
-  transition: transform 0.3s ease, background-color 0.3s ease;
 }
-.date-path:hover .date-marker {
-  background-color: var(--bs-secondary);
-  transform: scale(1.05);
+.date-path .date-marker.start {
+  top: 0;
+  left: 0;
 }
-.date-path:hover .line {
-  background-image: linear-gradient(
-    to bottom,
-    var(--bs-secondary) 33%,
-    rgba(255, 255, 255, 0) 0%
-  );
+.date-path .date-marker.end {
+  bottom: 0;
+  right: 0;
 }
 
 @media (max-width: 576px) {

--- a/resume.html
+++ b/resume.html
@@ -63,7 +63,11 @@
                                 <div class="col-sm-3">
                                     <div class="date-path">
                                         <div class="date-marker end">May 2025</div>
-                                        <div class="line"></div>
+                                        <div class="line">
+                                            <svg viewBox="0 0 100 100" preserveAspectRatio="none">
+                                                <path d="M0 0 C50 0 50 100 100 100" fill="none" stroke="var(--bs-primary)" stroke-width="2"/>
+                                            </svg>
+                                        </div>
                                         <div class="date-marker start">Aug 2023</div>
                                     </div>
                                 </div>
@@ -79,7 +83,11 @@
                                 <div class="col-sm-3">
                                     <div class="date-path">
                                         <div class="date-marker end">May 2020</div>
-                                        <div class="line"></div>
+                                        <div class="line">
+                                            <svg viewBox="0 0 100 100" preserveAspectRatio="none">
+                                                <path d="M0 0 C50 0 50 100 100 100" fill="none" stroke="var(--bs-primary)" stroke-width="2"/>
+                                            </svg>
+                                        </div>
                                         <div class="date-marker start">Jul 2016</div>
                                     </div>
                                 </div>
@@ -115,7 +123,11 @@
                                 <div class="col-sm-3">
                                     <div class="date-path">
                                         <div class="date-marker end">Jul 2023</div>
-                                        <div class="line"></div>
+                                        <div class="line">
+                                            <svg viewBox="0 0 100 100" preserveAspectRatio="none">
+                                                <path d="M0 0 C50 0 50 100 100 100" fill="none" stroke="var(--bs-primary)" stroke-width="2"/>
+                                            </svg>
+                                        </div>
                                         <div class="date-marker start">Aug 2020</div>
                                     </div>
                                 </div>
@@ -137,7 +149,11 @@
                                 <div class="col-sm-3">
                                     <div class="date-path">
                                         <div class="date-marker end">May 2025</div>
-                                        <div class="line"></div>
+                                        <div class="line">
+                                            <svg viewBox="0 0 100 100" preserveAspectRatio="none">
+                                                <path d="M0 0 C50 0 50 100 100 100" fill="none" stroke="var(--bs-primary)" stroke-width="2"/>
+                                            </svg>
+                                        </div>
                                         <div class="date-marker start">Jan 2025</div>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- redesign resume timeline
  - remove hover animations
  - place start marker top-left and end marker bottom-right
  - use a curved SVG path between markers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687498698f7c832d89c3bfaf363195aa