### PR TITLE
Improve curved timeline route

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -11740,51 +11740,44 @@ html {
 
 /* Timeline date markers used on the resume page */
 .date-path {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  height: 100%;
+  position: relative;
+  width: 100%;
+  height: 3rem;
 }
 .date-path .line {
-  flex-grow: 1;
-  width: 2px;
-  background-image: linear-gradient(
-    to bottom,
-    var(--bs-primary) 33%,
-    rgba(255, 255, 255, 0) 0%
-  );
-  background-position: right;
-  background-size: 2px 8px;
-  background-repeat: repeat-y;
-  transition: background-color 0.3s ease;
+  position: absolute;
+  inset: 0;
+}
+.date-path .line svg {
+  width: 100%;
+  height: 100%;
 }
 .date-path .date-marker {
+  position: absolute;
   background-color: var(--bs-primary);
   color: #fff;
-  padding: 0.25rem 0.5rem;
+  padding: 0.5rem 0.7rem;
   border-radius: 50%;
-  font-size: 0.7rem;
+  font-size: 1.2rem;
   line-height: 1;
   text-align: center;
   font-weight: 600;
-  transition: transform 0.3s ease, background-color 0.3s ease;
 }
-.date-path:hover .date-marker {
-  background-color: var(--bs-secondary);
-  transform: scale(1.05);
+.date-path .date-marker.start {
+  top: 0;
+  left: 0;
+  transform: translate(-50%, -50%);
 }
-.date-path:hover .line {
-  background-image: linear-gradient(
-    to bottom,
-    var(--bs-secondary) 33%,
-    rgba(255, 255, 255, 0) 0%
-  );
+.date-path .date-marker.end {
+  bottom: 0;
+  right: 0;
+  transform: translate(50%, 50%);
 }
 
 @media (max-width: 576px) {
   .date-path .date-marker {
-    font-size: 0.6rem;
-    padding: 0.2rem 0.4rem;
+    font-size: 1rem;
+    padding: 0.4rem 0.6rem;
   }
 }
 @media (min-width: 1200px) {

--- a/resume.html
+++ b/resume.html
@@ -63,7 +63,11 @@
                                 <div class="col-sm-3">
                                     <div class="date-path">
                                         <div class="date-marker end">May 2025</div>
-                                        <div class="line"></div>
+                                        <div class="line">
+                                            <svg viewBox="0 0 100 100" preserveAspectRatio="none">
+                                                <path d="M0 0 C40 20 60 80 100 100" fill="none" stroke="var(--bs-primary)" stroke-width="2"/>
+                                            </svg>
+                                        </div>
                                         <div class="date-marker start">Aug 2023</div>
                                     </div>
                                 </div>
@@ -79,7 +83,11 @@
                                 <div class="col-sm-3">
                                     <div class="date-path">
                                         <div class="date-marker end">May 2020</div>
-                                        <div class="line"></div>
+                                        <div class="line">
+                                            <svg viewBox="0 0 100 100" preserveAspectRatio="none">
+                                                <path d="M0 0 C40 20 60 80 100 100" fill="none" stroke="var(--bs-primary)" stroke-width="2"/>
+                                            </svg>
+                                        </div>
                                         <div class="date-marker start">Jul 2016</div>
                                     </div>
                                 </div>
@@ -115,7 +123,11 @@
                                 <div class="col-sm-3">
                                     <div class="date-path">
                                         <div class="date-marker end">Jul 2023</div>
-                                        <div class="line"></div>
+                                        <div class="line">
+                                            <svg viewBox="0 0 100 100" preserveAspectRatio="none">
+                                                <path d="M0 0 C40 20 60 80 100 100" fill="none" stroke="var(--bs-primary)" stroke-width="2"/>
+                                            </svg>
+                                        </div>
                                         <div class="date-marker start">Aug 2020</div>
                                     </div>
                                 </div>
@@ -137,7 +149,11 @@
                                 <div class="col-sm-3">
                                     <div class="date-path">
                                         <div class="date-marker end">May 2025</div>
-                                        <div class="line"></div>
+                                        <div class="line">
+                                            <svg viewBox="0 0 100 100" preserveAspectRatio="none">
+                                                <path d="M0 0 C40 20 60 80 100 100" fill="none" stroke="var(--bs-primary)" stroke-width="2"/>
+                                            </svg>
+                                        </div>
                                         <div class="date-marker start">Jan 2025</div>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- reduce date-path height for a shorter line
- enlarge date markers and center them on the path
- adjust the SVG curve for a smoother spline

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687498698f7c832d89c3bfaf363195aa