### PR TITLE
Remove gradient from text

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -11590,9 +11590,7 @@ html {
 }
 
 .text-gradient {
-  background: -webkit-linear-gradient(315deg, #93c572 0%, #ffeb3b 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: #339d15;
 }
 
 .rounded-4 {


### PR DESCRIPTION
## Summary
- use a plain color for the `.text-gradient` class

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6889903ea9e4832d979e69f4e4f34ac5