### PR TITLE
Add icons to skills section

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -11813,3 +11813,14 @@ html {
     left: -2vw;
   }
 }
+/* Skills icons */
+.skills-icons i {
+    font-size: 3rem;
+    margin: 0.5rem;
+    transition: transform 0.3s;
+}
+.skills-icons i:hover {
+    transform: translateY(-5px) scale(1.2);
+
+}
+

--- a/projects.html
+++ b/projects.html
@@ -133,7 +133,7 @@
         <footer class="bg-white py-4 mt-auto">
             <div class="container px-5">
                 <div class="row align-items-center justify-content-between flex-column flex-sm-row">
-                    <div class="col-auto"><div class="small m-0">© 2025 Krutik Panchal. Some rights reserved. Open to collaboration!</div></div>
+                    <div class="col-auto"><div class="small m-0">© 2025 Krutik Panchal. Projects on <a href="https://github.com/Krutik4" target="_blank">GitHub</a>.</div></div>
                     <div class="col-auto">
                         <a class="small" href="index.html#contact">Contact</a>
                     </div>

--- a/resume.html
+++ b/resume.html
@@ -15,6 +15,7 @@
         <!-- Bootstrap icons-->
         <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css" rel="stylesheet" />
         <!-- Core theme CSS (includes Bootstrap)-->
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/devicons/devicon@v2.15.1/devicon.min.css" />
         <link href="css/styles.css" rel="stylesheet" />
     </head>
     <body class="d-flex flex-column h-100 bg-light">
@@ -91,18 +92,6 @@
                     </ul>
                 </div>
 
-                <!-- Skills -->
-                <div class="mb-5">
-                    <h4 class="fw-bolder d-flex align-items-center"><i class="bi bi-tools fs-2 text-gradient me-2"></i>Skills</h4>
-                    <ul>
-                        <li><strong>Programming:</strong> Python (boto3, PySpark, scikit-learn, pandas, NumPy), SQL, Java</li>
-                        <li><strong>Databases:</strong> MySQL, PostgreSQL, MongoDB, Neo4j, Redshift</li>
-                        <li><strong>Cloud & DevOps:</strong> AWS, Azure, Docker, Kubernetes, Jenkins CI/CD, Git, GitHub, GitLab, Linux</li>
-                        <li><strong>Big Data:</strong> Apache Spark, Apache Airflow, Kafka</li>
-                        <li><strong>Visualization:</strong> Power BI (Microsoft Certified Data Analyst), Tableau, Qlik Sense, Excel, matplotlib, seaborn</li>
-                        <li><strong>Machine Learning & AI:</strong> Supervised/Unsupervised Learning, Feature Selection, Hyperparameter Tuning, NLP (LLMs, RAG)</li>
-                    </ul>
-                </div>
 
                 <!-- Experience -->
                 <div class="mb-5">
@@ -150,6 +139,36 @@
                             </ul>
                         </li>
                     </ul>
+                </div>
+<!-- Skills -->
+                <div class="mb-5 text-center">
+                    <h4 class="fw-bolder d-flex justify-content-center align-items-center"><i class="bi bi-tools fs-2 text-gradient me-2"></i>Skills</h4>
+                    <div class="skills-icons d-flex flex-wrap justify-content-center mt-4">
+                        <i class="devicon-python-plain colored" title="Python"></i>
+                        <i class="devicon-java-plain colored" title="Java"></i>
+                        <i class="devicon-mysql-plain colored" title="MySQL"></i>
+                        <i class="devicon-postgresql-plain colored" title="PostgreSQL"></i>
+                        <i class="devicon-mongodb-plain colored" title="MongoDB"></i>
+                        <i class="devicon-neo4j-plain colored" title="Neo4j"></i>
+                        <i class="devicon-amazonwebservices-original colored" title="AWS"></i>
+                        <i class="devicon-azure-plain colored" title="Azure"></i>
+                        <i class="devicon-docker-plain colored" title="Docker"></i>
+                        <i class="devicon-kubernetes-plain colored" title="Kubernetes"></i>
+                        <i class="devicon-jenkins-plain colored" title="Jenkins"></i>
+                        <i class="devicon-git-plain colored" title="Git"></i>
+                        <i class="devicon-github-original colored" title="GitHub"></i>
+                        <i class="devicon-gitlab-plain colored" title="GitLab"></i>
+                        <i class="devicon-linux-plain colored" title="Linux"></i>
+                        <i class="devicon-apachespark-original colored" title="Apache Spark"></i>
+                        <i class="devicon-apacheairflow-plain colored" title="Apache Airflow"></i>
+                        <i class="devicon-apachekafka-original colored" title="Kafka"></i>
+                        <i class="bi bi-bar-chart-fill text-gradient" title="Power BI"></i>
+                        <i class="bi bi-graph-up text-gradient" title="Tableau"></i>
+                        <i class="bi bi-pie-chart-fill text-gradient" title="Qlik Sense"></i>
+                        <i class="bi bi-file-earmark-spreadsheet text-gradient" title="Excel"></i>
+                        <i class="devicon-matplotlib-plain colored" title="matplotlib"></i>
+                        <i class="bi bi-graph-up-arrow text-gradient" title="seaborn"></i>
+                    </div>
                 </div>
 
             </div>


### PR DESCRIPTION
## Summary
- move resume skills section to the end of the page
- display skills using icon grid and add hover animations
- include Devicon style sheet
- update footer on projects page with GitHub link

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_68899a0dbafc832da967df40d2fbf071