### PR TITLE
Add popup on contact form submit

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -54,7 +54,11 @@
                                     <a class="text-gradient" href="https://github.com/Krutik4"><i class="bi bi-github"></i></a>
                                     <a class="text-gradient" href="https://www.instagram.com/kruz_4/"><i class="bi bi-instagram"></i></a>
                                 </div>
-                                <form action="https://formsubmit.co/krutikpanchal44@gmail.com" method="POST">
+                                <div id="successAlert" class="alert alert-success text-center position-fixed top-0 start-50 translate-middle-x" role="alert" style="display:none;">
+                                    Thank you! Your message has been sent.
+                                </div>
+                                <form id="contactForm" action="https://formsubmit.co/krutikpanchal44@gmail.com" method="POST">
+                                    <input type="hidden" name="_next" value="contact.html" />
                                     <div class="form-floating mb-3">
                                         <input class="form-control" id="name" name="name" type="text" placeholder="Name" required />
                                         <label for="name">Name</label>

--- a/css/styles.css
+++ b/css/styles.css
@@ -11854,3 +11854,12 @@ html {
 
 }
 
+/* Form success alert */
+#successAlert {
+    opacity: 0;
+    transition: opacity 0.5s ease;
+}
+#successAlert.show {
+    opacity: 1;
+}
+

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -3,5 +3,34 @@
 * Copyright 2013-2023 Start Bootstrap
 * Licensed under MIT (https://github.com/StartBootstrap/startbootstrap-personal/blob/master/LICENSE)
 */
-// This file is intentionally blank
-// Use this file to add JavaScript to your project
+// Custom scripts
+document.addEventListener('DOMContentLoaded', function () {
+    const form = document.getElementById('contactForm');
+    const alertBox = document.getElementById('successAlert');
+    if (form) {
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const formData = new FormData(form);
+            fetch(form.action, {
+                method: 'POST',
+                body: formData,
+                headers: {
+                    'Accept': 'application/json'
+                }
+            }).then(() => {
+                if (alertBox) {
+                    alertBox.style.display = 'block';
+                    alertBox.classList.add('show');
+                    setTimeout(() => {
+                        alertBox.classList.remove('show');
+                        alertBox.style.display = 'none';
+                    }, 3000);
+                }
+                form.reset();
+            }).catch((err) => {
+                console.error('Form submission failed:', err);
+                form.reset();
+            });
+        });
+    }
+});


### PR DESCRIPTION
## Summary
- show a temporary success alert on the contact page
- prevent redirect by handling form submission via JavaScript
- keep the user on contact.html after submission

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a7db5b340832d9c4ba5c9a50aab95